### PR TITLE
fixed path for new version of composer

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -65,7 +65,7 @@ class Handler extends Application
         foreach ($this->categories[$this->hook] as $command) {
             $output->writeln("<comment> Running $this->hook hook </comment>");
 
-            $process = new Process($command, __DIR__ . '../../');
+            $process = new Process($command, __DIR__ . '/../../../../');
             $process->setTimeout(null);
             $output->write($command."......");
             if ($process->run() === 1) {


### PR DESCRIPTION
New version of composer with symfony4, got this error after pulling:
```
In Process.php line 300:

  The provided cwd does not exist.
```